### PR TITLE
Add RoutingOutcome and SaturationSignal types (RFC #35)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@threshold-labs/integration",
-  "version": "0.6.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@threshold-labs/integration",
-      "version": "0.6.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3"

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -225,6 +225,49 @@ export interface DataCredentialPayload {
   expiresAt: Date
 }
 
+// ── Sideslip Routing Types (RFC #35) ─────────────────────────────────────────
+
+/**
+ * Routing outcome — records how a model performed on a specific node.
+ * Maps sideslip's routing_outcomes table to the capability vocabulary.
+ * Each model-on-node invocation produces one outcome record.
+ *
+ * RFC #35: sideslip feedback — routing trust as a native capability system
+ */
+export interface RoutingOutcome {
+  /** Node identifier within the federation */
+  node_id: string
+  /** Model that handled the request (e.g. 'llama3.2', 'nemotron') */
+  model: string
+  /** Curvature score — measures output novelty/quality (higher = more novel) */
+  curvature: number
+  /** Whether the routing produced a successful result */
+  success: boolean
+  /** Execution duration in seconds */
+  duration: number
+}
+
+/**
+ * Saturation signal — detects when a model/substrate/domain combination
+ * has stopped producing useful outputs. Substrate-relative trust degradation.
+ *
+ * When is_saturated is true, the model on this substrate in this domain
+ * is no longer trustworthy for novel outputs — triggers model rotation
+ * and new topic seeds internally, and can inform external routing decisions.
+ *
+ * RFC #35: sideslip feedback — routing trust as a native capability system
+ */
+export interface SaturationSignal {
+  /** Average embedding similarity of recent outputs (saturation threshold: > 0.78) */
+  avg_similarity: number
+  /** Trend of curvature scores over recent window (declining < -0.01 indicates saturation) */
+  curvature_trend: number
+  /** Knowledge domain being evaluated (e.g. 'distributed-systems', 'classification') */
+  domain: string
+  /** Whether this model/substrate/domain combination is saturated */
+  is_saturated: boolean
+}
+
 // ── Capability Contract ──────────────────────────────────────────────────────
 
 export const CAPABILITY_CONTRACT = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,9 @@ export type {
   // RFC types (typed, not yet implemented)
   AttributionClaim,
   Correction,
+  // Sideslip routing types (RFC #35)
+  RoutingOutcome,
+  SaturationSignal,
   // Deprecated aliases
   IntegrationPattern,
   IntegrationTokenScope,


### PR DESCRIPTION
## Summary
- Adds `RoutingOutcome` interface to `contract.ts` — maps sideslip's `routing_outcomes` table (node_id, model, curvature, success, duration) to the capability vocabulary
- Adds `SaturationSignal` interface — exposes substrate-relative trust degradation (avg_similarity, curvature_trend, domain, is_saturated) so other apps can route around saturated substrates
- Exports both types from `index.ts`

Closes #35 (Phase 1 vocabulary layer — types only, no logic changes)

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Verify types are importable from `@threshold-labs/integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)